### PR TITLE
Fix URLs and License Specifier in pyproject.toml

### DIFF
--- a/src/main/resources/esa_snappy/pyproject.toml
+++ b/src/main/resources/esa_snappy/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-license = {text = "MIT"}
+license = "MIT"
 
 [tool.setuptools.dynamic]
 readme = {file = "README.md", content-type = "text/markdown"}
@@ -52,5 +52,6 @@ exclude = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/pypa/sampleproject"
-Issues = "https://github.com/pypa/sampleproject/issues"
+Repository = "https://github.com/senbox-org/esa-snappy.git"
+Homepage = "https://step.esa.int/main/"
+Issues = "https://github.com/senbox-org/esa-snappy/issues"


### PR DESCRIPTION
I noticed that on the page on PyPi, the project URLs were still the sample URLs, so I updated them to point towards this Repo, and the STEP homepage. 
I've also updated the license to use a SPDX license specifier instead of text as that method is apparently deprecated. 


If I may recommend, it might be better to also set up an organization on PyPi listed as a contributor, so its clearer that the `esa-snappy` package there is the official one. 